### PR TITLE
v0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/MickaelRigault/simsurvey/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.3.1'
-VERSION = '0.4.1-dev'
+VERSION = '0.4.1-dev2'
 
 try:
     from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ try:
     _has_setuptools = True
 except ImportError:
     from distutils.core import setup
+    _has_setuptools = False
 
 if __name__ == "__main__":
     if _has_setuptools:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/MickaelRigault/simsurvey/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.3.1'
-VERSION = '0.4.0-dev3'
+VERSION = '0.4.0'
 
 try:
     from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/MickaelRigault/simsurvey/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.3.1'
-VERSION = '0.4.1-dev2'
+VERSION = '0.4.0-dev3'
 
 try:
     from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ MAINTAINER = 'Ulrich Feindt'
 MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/MickaelRigault/simsurvey/'
 LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.3.1'
+DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.4.0'
 VERSION = '0.4.0'
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/MickaelRigault/simsurvey/'
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/MickaelRigault/simsurvey/tarball/0.3.1'
-VERSION = '0.3.1'
+VERSION = '0.4.1-dev'
 
 try:
     from setuptools import setup, find_packages

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.4.1-dev2"
+__version__ = "0.4.0-dev3"
 
 from simultarget import *
 from simulsurvey import *

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.3.1"
+__version__ = "0.4.0-dev"
 
 from simultarget import *
 from simulsurvey import *

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.4.0-dev3"
+__version__ = "0.4.0-dev4"
 
 from simultarget import *
 from simulsurvey import *

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.4.0-dev"
+__version__ = "0.4.1-dev2"
 
 from simultarget import *
 from simulsurvey import *

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.4.0-dev4"
+__version__ = "0.4.0"
 
 from simultarget import *
 from simulsurvey import *

--- a/simsurvey/models.py
+++ b/simsurvey/models.py
@@ -71,22 +71,7 @@ class BlackBodySource(sncosmo.Source):
                         blackbody(wave, self._parameters[2]))
 
 class MultiSource(sncosmo.Source):
-    """A simple spectral source for a transient with a 
-    black-body spectrum of constant temperature
-    The spectral flux density of this model is given by
-    .. math::
-       F(t, \lambda) = A \\times LC(t / s) \\times B(\lambda, T)
-    where _A_ is the amplitude, _s_ is the "stretch" and 
-    _T_ is the black-body temperature; LC is a dimensionless 
-    lightcurve that defines the time evolution of the flux 
-    while B is the black-body spectrum.
-    Parameters
-    ----------
-    phase : `~numpy.ndarray`
-        Phases in days.
-    flux : `~numpy.ndarray`
-        Model spectral flux density in arbitrary units.
-        Must have shape `(num_phases)`.
+    """
     """   
     _param_names = ['amplitude', 's', 'template_index']
     param_names_latex = ['A', 's', 'k']

--- a/simsurvey/models.py
+++ b/simsurvey/models.py
@@ -265,12 +265,14 @@ class SpectralIndexSource(sncosmo.Source):
 
     def _flux(self, phase, wave):
         wave = np.array(wave)
-        fluxparam_ = self._parameters[1:self._n_fluxparam+1]
+        fluxparam = self._parameters[1:self._n_fluxparam+1]
         specparam = self._parameters[self._n_fluxparam+1:
                                      self._n_fluxparam+self._n_specparam+1]
-        return np.array([(self._parameters[0]
+        return np.array([((self._parameters[0]
                           * self._fluxfunc(fluxparam, phase)
-                          * wave ** self._specfunc(specparam, phase)) 
+                          * wave ** self._specfunc(specparam, phase))
+                          if p_ >= self.minphase and p_ <= self.maxphase
+                          else np.zeros(wave.shape))
                          for p_ in phase])
 
 #######################################

--- a/simsurvey/models.py
+++ b/simsurvey/models.py
@@ -192,17 +192,20 @@ class ExpandingBlackBodySource(sncosmo.Source):
         return T
         
     def radius(self, phase):
-        param = self._parameters[self._n_tempparam+1:self._n_tempparam+self._n_radiusparam+1]
+        param = self._parameters[self._n_tempparam+1:
+                                 self._n_tempparam+self._n_radiusparam+1]
         R = self._radiusfunc(param, phase)
         try:
-            R[(phase < self.minphase()) | (phase > self.maxphase()) | (R < 0.)] = 0.
+            R[(phase < self.minphase())
+              | (phase > self.maxphase()) | (R < 0.)] = 0.
         except TypeError:
             if phase < self.minphase() or phase > self.maxphase() or R < 0.:
                 return 0.
         return R
     
     def luminosity(self, phase):
-        return 0.5670367 * self.temperature(phase)**4 * 4 * np.pi * (self.radius(phase)*6.957e8) **2
+        return (0.5670367 * self.temperature(phase)**4
+                * 4 * np.pi * (self.radius(phase)*6.957e8) **2)
     
     def _flux(self, phase, wave):
         wave = np.array(wave)
@@ -263,7 +266,8 @@ class SpectralIndexSource(sncosmo.Source):
     def _flux(self, phase, wave):
         wave = np.array(wave)
         fluxparam_ = self._parameters[1:self._n_fluxparam+1]
-        specparam = self._parameters[self._n_fluxparam+1:self._n_fluxparam+self._n_specparam+1]
+        specparam = self._parameters[self._n_fluxparam+1:
+                                     self._n_fluxparam+self._n_specparam+1]
         return np.array([(self._parameters[0]
                           * self._fluxfunc(fluxparam, phase)
                           * wave ** self._specfunc(specparam, phase)) 

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -978,22 +978,17 @@ class LightcurveCollection( BaseObject ):
             tar.add(fname)
             os.remove(fname)
 
-        with get_progressbar(3*len(self.lcs), notebook=notebook) as bar:
+        with get_progressbar(len(self.lcs), notebook=notebook) as bar:
             for k, lc_data in enumerate(self.lcs):
                 meta = self.meta[k]
                 lc = Table(data=lc_data,
                            meta={key: v for key, v in zip(meta.dtype.names, meta)})
                 lc.write(os.path.join(file_base, 'lc_%06i.fits'%k))
-                bar.update()
-
-            for k in range(len(self.lcs)):
                 tar.add(os.path.join(file_base, 'lc_%06i.fits'%k))
-                bar.update()
-            tar.close()
-
-            for k in range(len(self.lcs)):
                 os.remove(os.path.join(file_base, 'lc_%06i.fits'%k))
                 bar.update()
+
+            tar.close()
             os.rmdir(os.path.join(tmpdir, file_base))
 
         os.chdir(cwd)

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -601,8 +601,8 @@ class SurveyPlan( BaseObject ):
     # - Load Method        - #
     # ---------------------- #
     def load_opsim(self, filename, survey_table='Summary', field_table='Field',
-                   band_dict=None, skybright_key='filtSkyBright', default_skybright=21,
-                   zp=30):
+                   band_dict=None, skybright_key='filtSkyBright', skybright_factor=1.,
+                   default_skybright=21, zp=30):
         """
         see https://confluence.lsstcorp.org/display/SIM/Summary+Table+Column+Descriptions
         for format description
@@ -645,10 +645,10 @@ class SurveyPlan( BaseObject ):
         if skybright_key is not None:
             loaded[skybright_key] = np.array([(d if d is not None else default_skybright)
                                                  for d in loaded[skybright_key]])
-            loaded['skynoise'] = 10 ** (-0.4 * (loaded[skybright_key] - zp))
+            loaded['skynoise'] = 10 ** (-0.4 * (loaded[skybright_key] - zp)) / skybright_factor
         else:
             loaded['skynoise'] = np.ones(len(loaded['fieldRA']))
-            loaded['skynoise'] *= 10 ** (-0.4 * (default_skybright - zp))
+            loaded['skynoise'] *= 10 ** (-0.4 * (default_skybright - zp)) / skybright_factor
 
         if band_dict is not None:
             loaded['filter'] = [band_dict[band] for band in loaded['filter']]

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -919,6 +919,8 @@ class LightcurveCollection( BaseObject ):
         loaded = cPickle.load(open(filename))
         self._properties['lcs'] = loaded['lcs']
         self._properties['meta'] = loaded['meta']
+        if 'meta_rejected' in loaded.keys():
+            self._properties['meta_rejected'] = loaded['meta_rejected']
         if 'stats' in loaded.keys():
             self._derived_properties['stats'] = loaded['stats']
         if 'side' in loaded.keys():
@@ -929,6 +931,7 @@ class LightcurveCollection( BaseObject ):
         """
         cPickle.dump({'lcs': self._properties["lcs"],
                       'meta': self._properties["meta"],
+                      'meta_rejected': self._properties["meta_rejected"],
                       'stats': self._derived_properties["stats"],
                       'side': self._side_properties},
                      open(filename, 'w'))

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -908,12 +908,18 @@ class LightcurveCollection( BaseObject ):
         loaded = cPickle.load(open(filename))
         self._properties['lcs'] = loaded['lcs']
         self._properties['meta'] = loaded['meta']
+        if 'stats' in loaded.keys():
+            self._derived_properties['stats'] = loaded['stats']
+        if 'side' in loaded.keys():
+            self._side_properties = loaded['side']
 
     def save(self, filename):
         """
         """
         cPickle.dump({'lcs': self._properties["lcs"],
-                      'meta': self._properties["meta"]},
+                      'meta': self._properties["meta"],
+                      'stats': self._derived_properties["stats"],
+                      'side': self._side_properties},
                      open(filename, 'w'))
 
     # ---------------------- #

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -62,8 +62,6 @@ class SimulSurvey( BaseObject ):
 
         if plan is not None:
             self.set_plan(plan)
-
-        if instprop is not None:
             self.set_instruments(instprop)
 
         if blinded_bias is not None:
@@ -228,7 +226,7 @@ class SimulSurvey( BaseObject ):
 
     # -------------
     # - Instruments
-    def set_instruments(self,properties):
+    def set_instruments(self, properties):
         """
         properties must be a dictionary containing the
         instruments' information (bandname,gain,zp,zpsys,err_calib) related
@@ -242,12 +240,16 @@ class SimulSurvey( BaseObject ):
         """
         prop = deepcopy(properties)
         for band,d in prop.items():
-            gain,zp,zpsys = d.pop("gain"),d.pop("zp"),d.pop("zpsys","ab")
+            gain,zp,zpsys = d.pop("gain", 1.), d.pop("zp", None), d.pop("zpsys","ab")
             err_calib = d.pop("err_calib", None)
             if gain is None or zp is None:
                 raise ValueError('gain or zp is None or not defined for %s'%band)
-            self.add_instrument(band,gain,zp,zpsys,err_calib,
+            self.add_instrument(band, gain, zp, zpsys, err_calib,
                                 update=False,**d)
+
+        for b_ in np.unique(self.pointings["band"]):
+            if b_ not in self.instruments.keys():
+                self.add_instrument(b_, 1., 30., 'ab', None, update=False)
 
         #self._reset_observations_()
 

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -1193,11 +1193,10 @@ class LightcurveCollection( BaseObject ):
 # = Lightcurve statistics = #
 # ========================= #
 def get_p_det_last(lc, thr=5., n_samenight=2):
+    """
+    """
     mask_det = lc['flux']/lc['fluxerr'] > thr
-    lc_nights = np.unique([int(t_) for t_ in lc['time']])
-    idx_nights = [np.array([k for k in xrange(len(lc)) 
-                            if int(lc['time'][k]) == t_]) 
-                  for t_ in lc_nights]
+    idx_nights = identify_nights(lc['time'])
         
     if np.sum(mask_det) > 1:
         mult_det = [k_ for k_, idx_ in enumerate(idx_nights)
@@ -1221,11 +1220,30 @@ def get_p_det_last(lc, thr=5., n_samenight=2):
         
     return p0, p1, dt
 
+def identify_nights(t, interval=0.25):
+    """
+    """
+    bins = np.arange(int(min(t_)), int(max(t_)) + 1.01, interval)
+    t_binned, _ = np.histogram(t_, bins=bins)
+
+    k = 0
+    idx_nights = [[]]
+    for n_ in t_binned:
+        if n_ == 0 and len(idx_nights[-1]) > 0:
+            idx_nights.append([])
+        else:
+            idx_nights[-1].extend(range(k, k+n_))
+            k += n_
+
+    return [np.array(idx_) for idx_ in idx_nights]
+
 def get_lc_max(lc, band):
-     lc_b = lc[lc['band'] == band]
-     if len(lc_b) > 0:
-         max_flux = np.max(lc_b['flux'])
-         zp = lc_b['zp'][lc_b['flux'] == max_flux]
-         return -2.5 * np.log10(max_flux) + zp
-     else:
-         return 99.
+    """
+    """
+    lc_b = lc[lc['band'] == band]
+    if len(lc_b) > 0:
+        max_flux = np.max(lc_b['flux'])
+        zp = lc_b['zp'][lc_b['flux'] == max_flux]
+        return -2.5 * np.log10(max_flux) + zp
+    else:
+        return 99.

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -529,7 +529,8 @@ class SurveyPlan( BaseObject ):
             return
 
         self.create(time=time,ra=ra,dec=dec,band=band,skynoise=skynoise,
-                    obs_field=obs_field,fields=fields, load_opsim=load_opsim, **kwargs)
+                    obs_field=obs_field, width=width, height=height, fields=fields,
+                    load_opsim=load_opsim, **kwargs)
 
     def create(self, time=None, ra=None, dec=None, band=None, skynoise=None, 
                obs_field=None, width=7.295, height=7.465, fields=None, 

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -999,9 +999,9 @@ class LightcurveCollection( BaseObject ):
         if self._properties[meta_name] is None:
             keys = [k for k in info.keys()]
             dtypes = [type(v) for v in info.values()]
-            self._create_meta_(keys, dtypes)
+            self._create_meta_(keys, dtypes, suffix)
 
-        for k in self.meta.dtype.names:
+        for k in self._properties[meta_name].keys():
             self._properties[meta_name][k] = np.append(
                 self._properties[meta_name][k],
                 info[k]
@@ -1144,12 +1144,12 @@ class LightcurveCollection( BaseObject ):
         if (self._properties["meta"] is not None and
             self._properties["meta_rejected"] is not None):
             out = odict()
-            for k in self.meta.keys():
+            for k in self.meta.dtype.names:
                 out[k] = np.concatenate((self.meta[k], self.meta_rejected[k]))
-            retunr dict_to_array(out)
+            return dict_to_array(out)
         elif self._properties["meta_rejected"] is None:
             return self.meta
-        elif self._properies["meta"] is None:
+        elif self._properties["meta"] is None:
             return self.meta_rejected
         else:
             return None

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -1197,7 +1197,7 @@ def get_p_det_last(lc, thr=5., n_samenight=2):
     """
     mask_det = lc['flux']/lc['fluxerr'] > thr
     idx_nights = identify_nights(lc['time'])
-        
+
     if np.sum(mask_det) > 1:
         mult_det = [k_ for k_, idx_ in enumerate(idx_nights)
                     if np.sum(mask_det[idx_]) >= n_samenight]
@@ -1223,19 +1223,19 @@ def get_p_det_last(lc, thr=5., n_samenight=2):
 def identify_nights(t, interval=0.25):
     """
     """
-    bins = np.arange(int(min(t_)), int(max(t_)) + 1.01, interval)
-    t_binned, _ = np.histogram(t_, bins=bins)
+    bins = np.arange(int(min(t)), int(max(t)) + 1.01, interval)
+    t_binned, _ = np.histogram(t, bins=bins)
 
     k = 0
     idx_nights = [[]]
-    for n_ in t_binned:
-        if n_ == 0 and len(idx_nights[-1]) > 0:
+    for n in t_binned:
+        if n == 0 and len(idx_nights[-1]) > 0:
             idx_nights.append([])
         else:
-            idx_nights[-1].extend(range(k, k+n_))
-            k += n_
+            idx_nights[-1].extend(range(k, k + n))
+            k += n
 
-    return [np.array(idx_) for idx_ in idx_nights]
+    return [np.array(idx_) for idx_ in idx_nights if len(idx_) > 0]
 
 def get_lc_max(lc, band):
     """

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -3,6 +3,7 @@
 
 """This module contains generators for simulated transients"""
 
+import os
 import warnings
 import numpy as np
 from numpy.random import uniform, normal

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -98,7 +98,7 @@ class TransientGenerator( BaseObject ):
         self.create(**kwargs)
 
     def create(self, zrange=(0.0, 0.2), ratekind="basic", ratefunc=None,
-               ntransient=None, type_=None, template=None, load=False,
+               ntransient=None, transienttype=None, template=None, load=False,
                mjd_range=(57754.0,58849.0),
                ra_range=(0,360), dec_range=(-90,90),
                mw_exclusion=0, sfd98_dir=None, transientprop=None, err_mwebv=0.01):
@@ -123,7 +123,7 @@ class TransientGenerator( BaseObject ):
                                          "mw_exclusion":mw_exclusion})
 
             self.set_transient_parameters(ratekind=ratekind, ratefunc=ratefunc,
-                                          type_=type_, template=template,
+                                          transienttype=transienttype, template=template,
                                           ntransient=ntransient,
                                           update=False, **transientprop)
 
@@ -190,7 +190,8 @@ class TransientGenerator( BaseObject ):
             self._update_()
 
     def set_transient_parameters(self,ratekind="basic", ratefunc=None,
-                                 ntransient=None, update=True, type_=None,
+                                 ntransient=None, update=True,
+                                 transienttype=None,
                                  template=None, **kwargs):
         """
         This method will define the transient properties.
@@ -199,8 +200,8 @@ class TransientGenerator( BaseObject ):
             self._properties["transient_coverage"] = {}
 
         # - you are good to fill it
-        if type_ is not None:
-            self._properties["transient_coverage"]["transienttype"] = type_
+        if transienttype is not None:
+            self._properties["transient_coverage"]["transienttype"] = transienttype
         if template is not None:
             self._properties["transient_coverage"]["template"] = template
         if ratekind is not None:

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1103,7 +1103,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
     # - IIP snana basic
     # - SpectralIndexSource
 
-    def lightcurve_Ia_salt2_basic(self, redshifts, model=None,
+    def lightcurve_Ia_salt2_basic(self, redshifts, model,
                                   color_mean=0, color_sigma=0.1,
                                   stretch_mean=0, stretch_sigma=1,
                                   alpha=0.13, beta=3.,
@@ -1117,17 +1117,17 @@ class LightCurveGenerator( _PropertyGenerator_ ):
             
        
         for z, x1_, c_ in zip(redshifts, x1, c):
-            self.model.set(z=z, x1=x1_, c=c_)
+            model.set(z=z, x1=x1_, c=c_)
             mabs = normal(-19.3, 0.1)
             mabs -= alpha*x1_ - beta*c_            
-            self.model.set_source_peakabsmag(mabs, 'bessellb', 'ab', cosmo=cosmo)
-            x0.append(self.model.get('x0'))
+            model.set_source_peakabsmag(mabs, 'bessellb', 'ab', cosmo=cosmo)
+            x0.append(model.get('x0'))
         
         return {'x0': np.array(x0),
                 'x1': x1,
                 'c': c}
     
-    def lightcurve_Ia_salt2_realistic(self, redshifts, model=None,
+    def lightcurve_Ia_salt2_realistic(self, redshifts, model,
                                       mabs_mean=-19.3, mabs_sigma=0.12,
                                       color_mean=0, color_sigma=0.1,
                                       stretch_mean=(0.5, -1), stretch_sigma=(1, 1),
@@ -1152,11 +1152,11 @@ class LightCurveGenerator( _PropertyGenerator_ ):
 
         x0 = []
         for k,z in enumerate(redshifts):
-            self.model.set(z=z, x1=x1[k], c=c[k])
+            model.set(z=z, x1=x1[k], c=c[k])
             mabs = normal(mabs_mean, mabs_sigma)
             mabs -= alpha*x1[k] - beta*c[k]
-            self.model.set_source_peakabsmag(mabs, 'bessellb', 'ab', cosmo=cosmo)
-            x0.append(self.model.get('x0'))
+            model.set_source_peakabsmag(mabs, 'bessellb', 'ab', cosmo=cosmo)
+            x0.append(model.get('x0'))
             
         ntransient = len(redshifts)
         

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1042,6 +1042,14 @@ class LightCurveGenerator( _PropertyGenerator_ ):
                              effect_names=['host'],
                              effect_frames=['rest'])
 
+    def model_generic_SpectralIndex(self, **kwargs):
+        """
+        """
+        return sncosmo.Model(source=SpectralIndexSource(**kwargs),
+                             effects=[sncosmo.CCM89Dust()],
+                             effect_names=['host'],
+                             effect_frames=['rest'])
+
     # ============================ #
     # = LC Parameter randomizers = #
     # ============================ #
@@ -1172,11 +1180,19 @@ class LightCurveGenerator( _PropertyGenerator_ ):
             'hostr_v': r_v * np.ones(len(redshifts)),
             'hostebv': np.random.exponential(ebv_rate, len(redshifts))
         }
-        
 
+    def lightcurve_generic_SpectralIndex_basic(self, redshifts, model,
+                                    mag=(-18., .1),
+                                    r_v=2., ebv_rate=0.11,
+                                    **kwargs):
+        """
+        """
+        return lightcurve_scaled_to_mag(redshifts, model, mag=mag,
+                                        r_v=r_v, ebv_rate=ebv_rate, **kwargs)
 
     def lightcurve_Ia_salt2_hostdependent():
         raise NotImplementedError("To be done")
+
     # ========================== #
     # = Properties             = #
     # ========================== #
@@ -1188,10 +1204,6 @@ class LightCurveGenerator( _PropertyGenerator_ ):
     def known_lightcurve_simulations(self):
         return self._parse_rate_("lightcurve")
     
-    # @property
-    # def known_Ia_lightcurve_simulation(self):
-    #     return self._parse_rate_("lightcurve_Ia")
-
     @property
     def known_models(self):
         return self._parse_rate_("model")

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1256,17 +1256,17 @@ class LightCurveGenerator( _PropertyGenerator_ ):
 
     def lightcurve_generic_ExpandingBlackBody_basic(redshifts, model,
                                                     sig_mag=0.1,
-                                                    r_v=2., ebv_rate=0.11
+                                                    r_v=2., ebv_rate=0.11,
                                                     cosmo=PlancK15,
                                                     **kwargs):
-    """
-    """
-    return {
-        'd': (cosmo.luminosity_distance.value
-              * 10**(-0.4*np.random.normal(0, sig_mag))),
-        'hostr_v': r_v * np.ones(len(redshifts)),
-        'hostebv': np.random.exponential(ebv_rate, len(redshifts))
-    }
+        """
+        """
+        return {
+            'd': (cosmo.luminosity_distance.value
+                  * 10**(-0.4*np.random.normal(0, sig_mag))),
+            'hostr_v': r_v * np.ones(len(redshifts)),
+            'hostebv': np.random.exponential(ebv_rate, len(redshifts))
+        }
         
 
 

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -30,7 +30,7 @@ def get_sn_generator(zrange,ratekind="basic",**kwargs):
                          **kwargs)
 
 def get_transient_generator(zrange,ratekind="basic",ratefunc=None,
-                        ra_range=[-180,180], dec_range=[-90,90],
+                        ra_range=[0,360], dec_range=[-90,90],
                         ntransient=None,
                         **kwargs):
     """
@@ -87,7 +87,7 @@ class TransientGenerator( BaseObject ):
 
     def __init__(self,zrange=[0.0,0.2], ratekind="basic", ratefunc=None,# How deep
                  mjd_range=[57754.0,58849.0],
-                 ra_range=(-180,180),dec_range=(-90,90), # Where, see also kwargs
+                 ra_range=(0,360),dec_range=(-90,90), # Where, see also kwargs
                  ntransient=None,empty=False,sfd98_dir=None,**kwargs):
         """
         """
@@ -105,7 +105,7 @@ class TransientGenerator( BaseObject ):
     def create(self,zrange,ratekind="basic",ratefunc=None,
                ntransient=None,type_=None,
                mjd_range=[57754.0,58849.0],
-               ra_range=(-180,180),dec_range=(-90,90),
+               ra_range=(0,360),dec_range=(-90,90),
                mw_exclusion=0,sfd98_dir=None,transientprop={},err_mwebv=0.01):
         """
         """

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -22,16 +22,8 @@ from utils.tools import kwargs_extract, kwargs_update, range_args
 
 _d2r = np.pi / 180
 
-__all__ = ["get_sn_generator", "get_transient_generator",
+__all__ = ["get_transient_generator",
            "generate_transients", "generate_lightcurves"]
-
-
-def get_sn_generator(zrange,ratekind="basic",**kwargs):
-    """
-    This function enables to load the generator of supernovae
-    """
-    return SNIaGenerator(ratekind=ratekind,zrange=zrange,
-                         **kwargs)
 
 def get_transient_generator(zrange,ratekind="basic",ratefunc=None,
                             ra_range=[0,360], dec_range=[-90,90],
@@ -804,78 +796,10 @@ class TransientGenerator( BaseObject ):
         """
         """
         return self.transient_coverage["lightcurve_prop"]
-    
-#######################################
-#                                     #
-# Generator: SN Ia                    #
-#                                     #
-#######################################
-class SNIaGenerator( TransientGenerator ):
-    """
-    This child Class enable to add the SN properties to the
-    transient generator.
-    """
-    
-    # -------------------- #
-    # - Hacked Methods   - #
-    # -------------------- #
-    def set_transient_parameters(self,ratekind="basic",ratefunc=None,
-                                 ntransient=None,
-                                 lcsimulation="basic",
-                                 lcsource="salt2",type_=None,
-                                 update=True,lcsimul_prop={}):
-        """
-        Add to the TransientGenerator the SN Ia properties
-        """
-        # - If this works, you are good to go
-        type_= "Ia" if type_ is None or "Ia" not in type_ else type_
-        f = LightCurveGenerator().get_lightcurve_func(transient=type_,
-                                                      simulation=lcsimulation)
-
-        super(SNIaGenerator,self).set_transient_parameters(type_=type_,
-                                                           ratekind=ratekind,
-                                                           ratefunc=ratefunc,
-                                                           ntransient=ntransient,
-                                                           lcsource=lcsource,
-                                                           lcsimul_func=f,
-                                                           lcsimul_prop=lcsimul_prop,
-                                                           update=update)
         
-    # ----------------- #
-    # - Set Methods   - #
-    # ----------------- #
-    
-    
-    # =========================== #
-    # = Properties and Settings = #
-    # =========================== #
-    @property
-    def color(self):
-        if not self.has_lightcurves() or "c" not in self.lightcurve:
-            raise AttributeError("no 'lightcurve' defined or no color ('c') on it")
-        return np.asarray(self.lightcurve["c"])
-
-    @property
-    def x1(self):
-        if not self.has_lightcurves() or "x1" not in self.lightcurve:
-            raise AttributeError("no 'lightcurve' defined or no x1 on it")
-        return np.asarray(self.lightcurve["x1"])
-
-    @property
-    def host(self):
-        if not self.has_host_param():
-            return np.asarray([None]*self.ntransient)
-        return np.asarray(self.lightcurve["host"])
-
-    def has_host_param(self):
-        if not self.has_lightcurves():
-            raise AttributeError("no 'lightcurve' defined")
-        return True if "host" in self.lightcurve_param_names \
-          else False
-    
 #######################################
 #                                     #
-# Generator: SN Rate                  #
+# Generator: Transient Rate           #
 #                                     #
 #######################################
 class _PropertyGenerator_(BaseObject):

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1115,7 +1115,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
         x1 = normal(stretch_mean, stretch_sigma, ntransient)
         c = normal(color_mean, color_sigma, ntransient)
             
-       
+        x0 = []
         for z, x1_, c_ in zip(redshifts, x1, c):
             model.set(z=z, x1=x1_, c=c_)
             mabs = normal(-19.3, 0.1)
@@ -1160,9 +1160,9 @@ class LightCurveGenerator( _PropertyGenerator_ ):
             
         ntransient = len(redshifts)
         
-        return {'x0':np.array(x0),
-                'x1':np.array(x1),
-                'c':np.array(c)}
+        return {'x0': np.array(x0),
+                'x1': np.array(x1),
+                'c': np.array(c)}
 
     def lightcurve_Ia_hsiao_basic(self, redshifts, model,
                                   mag=(-19.3, 0.1),

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1167,11 +1167,17 @@ class LightCurveGenerator( _PropertyGenerator_ ):
     def lightcurve_Ia_hsiao_basic(self, redshifts, model,
                                   mag=(-19.3, 0.1),
                                   r_v=2., ebv_rate=0.11,
+                                  alpha=1.3,
                                   **kwargs):
         """
         """
-        return lightcurve_scaled_to_mag(redshifts, model, mag=mag,
-                                            r_v=r_v, ebv_rate=ebv_rate, **kwargs)
+        out = lightcurve_scaled_to_mag(redshifts, model, mag=mag,
+                                       r_v=r_v, ebv_rate=ebv_rate, **kwargs)
+
+        out['s'] = np.random.normal(1., 0.1, len(redshifts))
+        out['amplitude'] *= 10 ** (0.4 * alpha * (out['s'] - 1))
+
+        return out
 
     # ----------------- #
     # - CC LC         - #

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -920,20 +920,8 @@ class RateGenerator( _PropertyGenerator_ ):
         function(z)
         """
         # ---------------
-        # - Transients
-        # if transient is None or transient == "":
-        #     avialable_rates = self.known_rates
-        #     transient = None
-        # elif transient == "Ia":
-        #     avialable_rates = self.known_Ia_rates
-        # elif ratekind not in ["custom"]:
-        #     raise ValueError("'%s' is not a known transient"%transient)
-    
-        # ---------------
         # - Rate Kinds
-        if ratekind == "custom":
-            if ratefunc is None:
-                raise ValueError("Ratekind 'custom' requires ratefunc")
+        if ratefunc is not None:
             return ratefunc
 
         name = '%s_%s'%(transient, ratekind)
@@ -1229,7 +1217,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
 
     def lightcurve_IIn_nugent_basic(self, redshifts, model,
                                     mag=(-18.5, 1.4),
-                                    mag_dist_trunc=(-1e6, 1),
+                                    mag_dist_trunc=(-1, 1e6),
                                     r_v=2., ebv_rate=0.11,
                                     **kwargs):
         """

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -10,7 +10,7 @@ import sncosmo
 
 from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
 from scipy.stats import truncnorm
-from astropy.cosmology import FlatLambdaCDM, Planck15
+from astropy.cosmology import Planck15
 
 from propobject import BaseObject
 
@@ -252,7 +252,7 @@ class TransientGenerator( BaseObject ):
             "param_func_kwargs": lcsimul_prop
         }
 
-        if model is None:
+        if lcmodel is None:
             self.set_model(
                 LightCurveGenerator().get_model(
                     transient=self.transienttype,
@@ -1257,7 +1257,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
     def lightcurve_generic_ExpandingBlackBody_basic(redshifts, model,
                                                     sig_mag=0.1,
                                                     r_v=2., ebv_rate=0.11,
-                                                    cosmo=PlancK15,
+                                                    cosmo=Planck15,
                                                     **kwargs):
         """
         """

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -1058,7 +1058,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
         """
         name = "%s_%s"%(transient, template)
         if name in self.known_models:
-            return eval("self.model_%s()"%name)
+            return eval("self.model_%s(**kwargs)"%name)
         else:
             raise ValueError("No lightcurve model available for '%s'"%name)
 
@@ -1087,8 +1087,8 @@ class LightCurveGenerator( _PropertyGenerator_ ):
         """
         sncosmo.get_source('hsiao', version='3.0')
         p, w, f = sncosmo.read_griddata_fits(
-            os.path.join(sncosmo.get_cache_dir(),
-                         'models/hsiao/Hsiao_SED_V3.fits')
+            os.path.join(sncosmo.builtins.get_cache_dir(),
+                         'sncosmo/models/hsiao/Hsiao_SED_V3.fits')
         )
 
         return sncosmo.Model(
@@ -1255,7 +1255,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
         """
         """
         return {
-            'd': (cosmo.luminosity_distance.value
+            'd': (cosmo.luminosity_distance(redshifts).value
                   * 10**(-0.4*np.random.normal(0, sig_mag))),
             'hostr_v': r_v * np.ones(len(redshifts)),
             'hostebv': np.random.exponential(ebv_rate, len(redshifts))

--- a/simsurvey/utils/skybins.py
+++ b/simsurvey/utils/skybins.py
@@ -383,7 +383,7 @@ class HealpixBins( BaseBins ):
         bd = hp.boundaries(self.nside, k, step=steps, nest=self.nest)
         dec_raw, ra_raw = hp.vec2ang(np.transpose(bd))
 
-        ra = ((ra_raw / _d2r + 180) % 360) - 180
+        ra = (ra_raw / _d2r) % 360
         dec = 90 - dec_raw / _d2r
 
         return self.split_bin(ra, dec, max_stepsize, edge) 
@@ -813,7 +813,7 @@ class SurveyField( BaseObject ):
         r, d = rot_xz_sph(r, d, self.dec)
         r += self.ra
 
-        r = ((r + 180) % 360 ) - 180
+        r = r % 360
 
         return r, d
 
@@ -846,7 +846,7 @@ class SurveyField( BaseObject ):
         dec4 = np.linspace(self.dec - self.height/2, self.dec + self.height/2, steps)
         ra4 = self.ra - self.width/2/np.cos(dec4*_d2r)
 
-        ra = ((np.concatenate((ra1, ra2, ra3, ra4)) + 180) % 360 ) - 180 
+        ra = (np.concatenate((ra1, ra2, ra3, ra4)) % 360 )  
         dec = np.concatenate((dec1, dec2, dec3, dec4))
 
         return ra, dec

--- a/simsurvey/utils/skybins.py
+++ b/simsurvey/utils/skybins.py
@@ -906,9 +906,9 @@ class SurveyField( BaseObject ):
             center_ = np.array([np.mean(c_[:,k]) for k in range(2)])
             tmp = np.zeros((4,2))
             for c__ in c_:
-                if (c_[0] - center_[0]) > 0:
+                if (c__[0] - center_[0]) > 0:
                     # Right
-                    if (c_[1] - center_[1]) > 0:
+                    if (c__[1] - center_[1]) > 0:
                         # Top
                         tmp[2] = c__
                     else:
@@ -916,7 +916,7 @@ class SurveyField( BaseObject ):
                         tmp[3] = c__
                 else:
                     # Left
-                    if (c_[1] - center_[1]) > 0:
+                    if (c__[1] - center_[1]) > 0:
                         # Top
                         tmp[1] = c__
                     else:


### PR DESCRIPTION
* TransientGenerator objects are now serializable as pickle files and can be reloaded (to repeat the exact same simulation)
* SurveyPlan.cadence renamed to pointings (cadence still works but will be deprecated)
* ZP can be varied between pointings
* Comment column added to SurveyPlan.pointings, e.g. to allow tracking different observing programs like MSIP, fast-g, TOO.
* New SED sources: black body parameterized by distance, radius, and temperature (the latter two as functions of time) and simple source based on flux normalization and spectral index as functions of time
* More models (Hsiao Ia, Nugent CC and expanding black body) are now available through options of TransientGenerator (examples will be added to the repo's wiki soon)
* LightcurveCollection now filters out SNe that did not pass the threshold and collects simple stats (e.g. phase of detection, time between detection and last non-detection)
* Simulation parameters for all transients in observed fields now saved (but not all LCs)
* SNIaGenerator removed 
* Filter functions added to LightcurveCollection (This will create new Lightcurve collection based func that can modify the Lightcurve, e.g. to throw out certain epochs. This can also be used to filter by redshift etc..)
* LightcurveCollection objects can be saved as tarballs of fits tables. (It cannot be loaded from this format though.)